### PR TITLE
fix(nebula-cli): resolve cli path mismatches on Windows 

### DIFF
--- a/dsl/nebula/src/cli/cli.ts
+++ b/dsl/nebula/src/cli/cli.ts
@@ -1,13 +1,14 @@
 import { Command } from "commander";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { CodeGenerator } from "./engine/code-generator.js";
 import { DEFAULT_OUTPUT_DIR } from "./engine/types.js";
 import { ErrorHandler, ErrorUtils } from "./utils/error-handler.js";
 import { InputValidator } from "./utils/input-validator.js";
 import chalk from "chalk";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packagePath = path.resolve(__dirname, "..", "..", "package.json");
 
 export default async function cli(): Promise<void> {

--- a/dsl/nebula/src/cli/utils/template-manager.ts
+++ b/dsl/nebula/src/cli/utils/template-manager.ts
@@ -3,6 +3,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import Handlebars from 'handlebars';
 import { ErrorHandler, ErrorUtils, ErrorSeverity } from './error-handler.js';
 
@@ -198,7 +199,7 @@ export class TemplateManager {
 
         
         const currentFileUrl = import.meta.url;
-        const currentFilePath = new URL(currentFileUrl).pathname;
+        const currentFilePath = fileURLToPath(currentFileUrl);
         const currentDir = path.dirname(currentFilePath);
         
         return path.join(currentDir, '../templates');


### PR DESCRIPTION
### Description
Fixes a bug where the CLI fails on Windows due to incorrect URI-to-path conversion.

### Changes
- Replaced manual `new URL().pathname` parsing with `fileURLToPath` from `node:url`.
- Ensures drive letters (e.g., `C:/`) and percent-encoded characters are handled correctly.

### Impact
The CLI can now correctly execute on Windows, without a file not found error.